### PR TITLE
fix: use OAP timezone instead of grafana ui timezone

### DIFF
--- a/src/constant.ts
+++ b/src/constant.ts
@@ -19,6 +19,7 @@ export const Fragments = {
   servicesTopolgy: "query queryData($serviceIds: [ID!]!, $duration: Duration!) {\n  topology: getServicesTopology(serviceIds: $serviceIds, duration: $duration) {\n    nodes {\n      id\n      name\n      type\n      isReal\n    }\n    calls {\n      id\n      source\n      detectPoints\n      target\n    }\n  }}",
   services: "query queryServices($duration: Duration!,$keyword: String!) {\n    services: getAllServices(duration: $duration, group: $keyword) {\n      id\n      name\n      group\n      layers\n    }\n  }",
   version: "query version { version }",
+  utc: "query queryOAPTimeInfo {\n    getTimeInfo {\n      timezone\n      currentTimestamp\n    }\n  }",
 };
 
 // proxy route

--- a/src/datasource.ts
+++ b/src/datasource.ts
@@ -57,11 +57,12 @@ export class DataSource extends DataSourceApi<MyQuery, MyDataSourceOptions> {
     const { range } = options;
     const from = range!.from.valueOf();
     const to = range!.to.valueOf();
-    let utc = -(new Date().getTimezoneOffset() / 60);
-
-    if (options.timezone !== 'browser') {
-      utc = dayjs().tz(options.timezone).utcOffset() / 60;
-    }
+    const  v =  {
+      query: Fragments.utc,
+      variables: {},
+    };
+    const resp = await this.doRequest(v);
+    const utc = resp.data.getTimeInfo.timezone / 100;
     const dates = this.timeFormat([this.getLocalTime(utc, new Date(from)), this.getLocalTime(utc, new Date(to))]);
     const duration = {
       start: this.dateFormatStep(dates.start, dates.step),


### PR DESCRIPTION
Use OAP timezone instead of grafana ui timezone.

Screenshots

<img width="1334" alt="1" src="https://github.com/apache/skywalking-grafana-plugins/assets/20871783/fd672250-6a34-4f3b-b046-6524b8b8348c">

<img width="1348" alt="2" src="https://github.com/apache/skywalking-grafana-plugins/assets/20871783/8b267436-f5a8-43cc-8b8d-0ec7acd00268">

Signed-off-by: Qiuxia Fan


